### PR TITLE
Fix algorithm used to calculate statistical ties.

### DIFF
--- a/app/Models/RpsMatch.php
+++ b/app/Models/RpsMatch.php
@@ -449,22 +449,11 @@ class RpsMatch extends Model implements RankedMatch
      */
     public function getOutcome(): string
     {
-        // If scores are identical, definite tie
-        if ($this->player1_score === $this->player2_score) {
-            return 't';
-        }
-
-        // Check if the difference is statistically significant
-        if (! Statistics::isScoreDifferenceSignificant(
-            $this->player1_score,
-            $this->player2_score,
-            $this->rounds_played
-        )) {
-            return 't'; // Statistical tie
-        }
-
-        // Otherwise, return winner based on score
-        return $this->player1_score > $this->player2_score ? '1' : '2';
+        return match ($this->winner_id) {
+            $this->player1_id => '1',
+            $this->player2_id => '2',
+            default => 't',
+        };
     }
 
     /**

--- a/app/Services/EloRatingService.php
+++ b/app/Services/EloRatingService.php
@@ -116,10 +116,6 @@ class EloRatingService
                 $player1 = $match->getPlayer1();
                 $player2 = $match->getPlayer2();
 
-                if (! $player1 || ! $player2) {
-                    continue;
-                }
-
                 $player1Elo = $player1->getAttribute($this->getEloColumnName($gameType));
                 $player2Elo = $player2->getAttribute($this->getEloColumnName($gameType));
 

--- a/app/Support/Statistics.php
+++ b/app/Support/Statistics.php
@@ -8,59 +8,102 @@ namespace App\Support;
 class Statistics
 {
     /**
-     * Default confidence level for statistical significance tests (approximately 95% confidence)
+     * The default Z-score for a 95% confidence level (two-tailed).
+     * This is the threshold for determining statistical significance.
      */
-    public const DEFAULT_CONFIDENCE_LEVEL = 2.0;
+    public const DEFAULT_Z = 1.96;
 
     /**
-     * Determines if the difference between two scores is statistically significant.
-     * Uses a binomial distribution model to determine if score differences could be due to random chance.
+     * Determines if the difference in scores between two players is statistically significant.
      *
-     * @param  int  $score1  First player's score
-     * @param  int  $score2  Second player's score
-     * @param  int  $totalRounds  Total number of rounds played
-     * @param  float  $confidenceLevel  Number of standard deviations for significance (default: 2.0 for ~95% confidence)
+     * @param  int  $score1         Player 1's number of wins
+     * @param  int  $score2         Player 2's number of wins
+     * @param  float  $confidenceZ  Z-score threshold for significance (default: 1.96 for ≈95% confidence)
      * @return bool True if the difference is statistically significant
      */
     public static function isScoreDifferenceSignificant(
         int $score1,
         int $score2,
-        int $totalRounds,
-        float $confidenceLevel = self::DEFAULT_CONFIDENCE_LEVEL
+        float $confidenceZ = self::DEFAULT_Z
     ): bool {
-        // Handle edge cases
-        if ($totalRounds <= 0) {
+        // Step 1: Compute how many rounds had an actual winner (i.e., not ties)
+        $decisiveRounds = $score1 + $score2;
+
+        // Step 2: Edge case: If there are no decisive rounds, we cannot evaluate anything
+        if ($decisiveRounds === 0) {
             return false;
         }
 
-        // For a binomial distribution with p=0.5 (equal chance of winning)
-        // the standard deviation is sqrt(n * p * (1-p))
-        $standardDeviation = sqrt($totalRounds * 0.5 * 0.5);
+        // Step 3: Compute the observed win proportion of Player 1
+        $pHat = $score1 / $decisiveRounds;
 
-        // Threshold for statistical significance based on confidence level
-        $threshold = $confidenceLevel * $standardDeviation;
+        // Step 4: Under the null hypothesis, we assume both players are equally good.
+        // That means the expected probability of Player 1 winning a round is 0.5
+        $pNull = 0.5;
 
-        // If absolute difference exceeds threshold, it's statistically significant
-        return abs($score1 - $score2) > $threshold;
+        // Step 5: Compute the standard deviation of the observed win proportion,
+        // assuming Player 1 has a true 50% win rate. This is based on binomial variance:
+        //     std dev = sqrt(p * (1 - p) / n)
+        $stdDev = sqrt($pNull * (1 - $pNull) / $decisiveRounds);
+
+        // Step 6: Convert the difference between observed and expected win rates into a z-score.
+        // This tells us how many "standard deviations" the result is away from what we'd expect by chance.
+        $zScore = ($pHat - $pNull) / $stdDev;
+
+        // Step 7: Compare the absolute z-score to our confidence threshold (default 1.96 for 95% two-sided).
+        // If it's greater, the win difference is unlikely due to chance, so we reject the null hypothesis.
+        return abs($zScore) > $confidenceZ;
     }
 
     /**
-     * Calculate the maximum allowable difference for statistical tie based on rounds played
+     * Calculate the maximum allowed score difference that is still considered
+     * statistically insignificant (i.e. a "tie") based on the number of decisive rounds.
      *
-     * @param  int  $totalRounds  Total number of rounds played
-     * @param  float  $confidenceLevel  Number of standard deviations for significance
-     * @return float The maximum difference that would still be considered a tie
+     * This is useful to explain *why* a match with an unequal score might still be
+     * considered a tie, if the observed difference is too small to be confidently
+     * distinguished from random noise.
+     *
+     * @param  int   $score1         Player 1's number of wins
+     * @param  int   $score2         Player 2's number of wins
+     * @param  float $confidenceZ    Z-score threshold (e.g. 1.96 for ≈95% confidence)
+     * @return float                 Maximum difference that would *not* be statistically significant
      */
-    public static function getSignificanceThreshold(
-        int $totalRounds,
-        float $confidenceLevel = self::DEFAULT_CONFIDENCE_LEVEL
+    public static function getDifferenceThreshold(
+        int $score1,
+        int $score2,
+        float $confidenceZ = self::DEFAULT_Z
     ): float {
-        if ($totalRounds <= 0) {
-            return 0;
+        // Step 1: Determine how many *decisive rounds* were played.
+        // Only rounds that ended in a win (not a tie) carry information about player skill.
+        // We count these as the sum of wins by Player 1 and Player 2.
+        $decisiveRounds = $score1 + $score2;
+
+        // Step 2: Edge case — if no one won any round, then there are zero decisive rounds.
+        // In that case, we can't measure any difference at all, so we return 0.
+        if ($decisiveRounds === 0) {
+            return 0.0;
         }
 
-        $standardDeviation = sqrt($totalRounds * 0.5 * 0.5);
+        // Step 3: Under the null hypothesis (H0), we assume both players are equally skilled.
+        // That means the true probability of either one winning any decisive round is 50%.
+        //
+        // Let D = (score1 - score2) be the *difference in wins*.
+        // If Player 1 and Player 2 were equally skilled, then D is expected to be around 0.
+        // But D is a random variable, and it will naturally vary just due to luck.
+        //
+        // What is the expected variability (standard deviation) of D?
+        // Turns out:
+        //   Var(D) = Var(2X - n) where X ~ Binomial(n, 0.5)
+        //          = 4 * Var(X)
+        //          = 4 * n * 0.5 * (1 - 0.5)
+        //          = n
+        //
+        // So the standard deviation of the score *difference* D is:
+        $stdDevOfDifference = sqrt($decisiveRounds);
 
-        return $confidenceLevel * $standardDeviation;
+        // Step 4: Convert the desired confidence level (e.g., z = 1.96 for 95%) into
+        // a maximum allowable difference. Any observed difference smaller than this
+        // is still plausible under the assumption of equal skill.
+        return $confidenceZ * $stdDevOfDifference;
     }
 }

--- a/app/Support/Statistics.php
+++ b/app/Support/Statistics.php
@@ -16,8 +16,8 @@ class Statistics
     /**
      * Determines if the difference in scores between two players is statistically significant.
      *
-     * @param  int  $score1         Player 1's number of wins
-     * @param  int  $score2         Player 2's number of wins
+     * @param  int  $score1  Player 1's number of wins
+     * @param  int  $score2  Player 2's number of wins
      * @param  float  $confidenceZ  Z-score threshold for significance (default: 1.96 for ≈95% confidence)
      * @return bool True if the difference is statistically significant
      */
@@ -63,10 +63,10 @@ class Statistics
      * considered a tie, if the observed difference is too small to be confidently
      * distinguished from random noise.
      *
-     * @param  int   $score1         Player 1's number of wins
-     * @param  int   $score2         Player 2's number of wins
-     * @param  float $confidenceZ    Z-score threshold (e.g. 1.96 for ≈95% confidence)
-     * @return float                 Maximum difference that would *not* be statistically significant
+     * @param  int  $score1  Player 1's number of wins
+     * @param  int  $score2  Player 2's number of wins
+     * @param  float  $confidenceZ  Z-score threshold (e.g. 1.96 for ≈95% confidence)
+     * @return float Maximum difference that would *not* be statistically significant
      */
     public static function getDifferenceThreshold(
         int $score1,

--- a/resources/views/components/rps/game-rules.blade.php
+++ b/resources/views/components/rps/game-rules.blade.php
@@ -83,60 +83,145 @@
         </h3>
 
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <!-- 📣 Plain-English “How it works” -->
             <div>
                 <h4 class="text-base font-medium text-gray-800 mb-2 flex items-center">
                     <x-phosphor-hand-pointing-fill class="w-4 h-4 mr-2 text-amber-600" />
-                    How Winners Are Determined
+                    How We Pick The Winner
                 </h4>
+
                 <p class="text-gray-600 mb-4">
-                    In most cases, the AI with more winning rounds wins the match. However, when both AIs perform similarly,
-                    statistical analysis is used to determine if the difference is meaningful or just random chance.
+                    First bot to grab <strong>50 wins</strong> usually wins the match.
+                    But if both bots are neck-and-neck we run a quick “is this just luck?” check.
+                    If the gap is tiny, we call it a tie so nobody brags without proof.
                 </p>
 
                 <div class="bg-blue-50 border-l-4 border-blue-300 px-4 py-3 rounded-r mb-4">
                     <div class="flex">
-                        <div class="flex-shrink-0">
-                            <x-phosphor-info-fill class="h-5 w-5 text-blue-500" />
-                        </div>
-                        <div class="ml-3">
-                            <p class="text-sm text-blue-700">
-                                <span class="font-semibold">Statistical Ties:</span> When score differences are small enough
-                                that they could be explained by random chance, matches are declared ties regardless of the
-                                numerical score difference.
-                            </p>
-                        </div>
+                        <x-phosphor-info-fill class="h-5 w-5 text-blue-500 flex-shrink-0" />
+                        <p class="ml-3 text-sm text-blue-700">
+                            <span class="font-semibold">Statistical Tie:</span>
+                            Scores different but difference is so small it could be pure coin-flip luck, not real skill.
+                        </p>
                     </div>
                 </div>
             </div>
 
+            <!-- 📏 Numbers people can feel -->
             <div>
                 <h4 class="text-base font-medium text-gray-800 mb-2 flex items-center">
                     <x-phosphor-sigma-fill class="w-4 h-4 mr-2 text-amber-600" />
-                    Statistical Significance
+                    How Big Is “Big Enough”?
                 </h4>
+
                 <p class="text-gray-600 mb-2">
-                    The statistical significance threshold scales with the number of rounds played:
+                    Rough guide (decisive rounds only, ties don’t count):
                 </p>
+
                 <ul class="space-y-1 list-inside text-gray-600 mb-4">
                     <li class="flex items-baseline">
                         <x-phosphor-dot class="size-4 text-amber-600 mr-1 flex-shrink-0" />
-                        <span><strong>50 rounds:</strong> ~7 point difference needed</span>
+                        <span><strong>50 rounds:</strong> need about <strong>14-point</strong> lead</span>
                     </li>
                     <li class="flex items-baseline">
                         <x-phosphor-dot class="size-4 text-amber-600 mr-1 flex-shrink-0" />
-                        <span><strong>100 rounds:</strong> ~10 point difference needed</span>
+                        <span><strong>100 rounds:</strong> need about <strong>20-point</strong> lead</span>
                     </li>
                     <li class="flex items-baseline">
                         <x-phosphor-dot class="size-4 text-amber-600 mr-1 flex-shrink-0" />
-                        <span><strong>150 rounds:</strong> ~12 point difference needed</span>
+                        <span><strong>150 rounds:</strong> need about <strong>24-point</strong> lead</span>
                     </li>
                 </ul>
+
                 <p class="text-sm text-gray-500 italic">
-                    This approach ensures that only meaningful skill differences affect rankings.
+                    Bigger match &rarr; we demand a bigger gap before yelling “Winner!”.
                 </p>
             </div>
         </div>
+
+        <!-- 🧑‍🔬 Optional nerd corner -->
+        <div x-data="{ open: false }" class="mt-6">
+            <button
+                @click="open = !open"
+                class="text-gray-600 hover:text-gray-800 flex items-center cursor-pointer"
+            >
+                <x-phosphor-flask-fill class="size-5 mr-2" />
+                Info for Nerds (don’t open if scared of math)
+                <x-phosphor-caret-down
+                    class="w-4 h-4 ml-1 transform transition-transform"
+                    x-bind:class="{ 'rotate-180': open }"
+                />
+            </button>
+
+            <div
+                x-show="open"
+                x-collapse
+                class="mt-4 text-gray-700 leading-relaxed rounded p-4 bg-gray-50"
+            >
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <!-- 📝 Short story version -->
+                    <div>
+                        <p>
+                            We run a <strong>95 % two-sided binomial z-test.</strong>
+                            It answers one question: “Is the score gap big enough that luck
+                            is an unlikely explanation?”
+                        </p>
+
+                        <ul class="list-disc list-inside mt-3 space-y-1">
+                            <li><em>Decisive rounds only.</em> Ties don’t help us judge skill.</li>
+                            <li>If the gap is below the cut-off, we say “statistical tie.”</li>
+                            <li>If the gap beats the cut-off, we say the leader showed real skill.</li>
+                        </ul>
+
+                        <a
+                            href="{{ config('playbench.github_repo_url') }}"
+                            target="_blank"
+                            class="mt-4 inline-flex items-center text-sm font-medium text-amber-600 hover:text-amber-500 hover:underline"
+                            rel="noopener noreferrer"
+                        >
+                            <x-phosphor-github-logo-fill class="w-4 h-4 mr-1" />
+                            Full implementation lives in the GitHub repo.
+                        </a>
+                    </div>
+
+                    <!-- 📐 Exact math, as compact as possible -->
+                    <div class="text-sm">
+                        <p><strong>Hypotheses</strong></p>
+                        <p>
+                            H₀: score₁ − score₂ = 0 (no skill)<br>
+                            H₁: score₁ − score₂ ≠ 0 (skill)
+                        </p>
+                        <p class="mt-3"><strong>Statistical Model</strong></p>
+                        <p>
+                            n = decisive rounds<br>
+                            X ~ Binomial(n, 0.5) &nbsp;(wins of Bot 1 under H₀)<br>
+                            D = score₁ − score₂ = 2X − n
+                        </p>
+
+                        <p class="mt-3"><strong>Under H₀</strong></p>
+                        <p>
+                            E[D] = 0  Var[D] = n → σ<sub>D</sub> = √n
+                        </p>
+
+                        <p class="mt-3"><strong>Test statistic</strong></p>
+                        <p>
+                            z = |D| / √n
+                        </p>
+
+                        <p class="mt-3"><strong>Decision rule (α = 0.05)</strong></p>
+                        <p>
+                            z &gt; 1.96 ⇔ |score₁ − score₂| &gt; 1.96 × √n
+                            → reject H₀ → call it “skill”
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+
     </div>
+
+
 
     <!-- ELO Ratings Explanation -->
     <div class="bg-white p-6 rounded-xl border border-gray-100 shadow-sm mb-8">

--- a/resources/views/rps/matches/show.blade.php
+++ b/resources/views/rps/matches/show.blade.php
@@ -148,13 +148,15 @@
                     <div class="ml-4 sm:ml-5 text-amber-700">
                         <h3 class="text-base sm:text-lg font-semibold text-amber-800">Statistical Tie</h3>
                         <p class="mt-1 text-sm">
-                            This match is considered a tie even though the scores are different. The score difference
-                            <span class="font-semibold">({{ abs($rpsMatch->player1_score - $rpsMatch->player2_score) }} points)</span>
-                            is not statistically significant with {{ $rpsMatch->rounds_played }} rounds played.
+                            This match is considered a tie even though the scores differ by
+                            <span class="font-semibold">{{ abs($rpsMatch->player1_score - $rpsMatch->player2_score) }} points</span>.
+                            With {{ $rpsMatch->getDecisiveRounds() }} decisive rounds (Rounds not ending in a tie), that gap is not large enough to be statistically significant
+                            at 95 % confidence.
                         </p>
                         <p class="mt-2 text-sm">
-                            For {{ $rpsMatch->rounds_played }} rounds, differences less than {{ Number::format($rpsMatch->getSignificanceThreshold(), 1) }} points
-                            could be explained by random chance alone, rather than by player skill.
+                            At this sample size, any difference below
+                            <span class="font-semibold">{{ Number::format($rpsMatch->getDifferenceThreshold(), 1) }} points</span>
+                            can still be explained by random chance rather than player skill.
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
We rip out the old algorithm (incorrect SD, included ties in _n_) and drop in a textbook two-tailed binomial _z_-test (95 % confidence, _z = 1.96_).  
Result: matches now labelled “statistical tie” jump from **42 % → 63 %** because we stopped over-claiming skill.

**Dataset impact (current prod DB)**

| Metric | Before | After |
|--------|--------|-------|
| Matches total | 292 | 292 |
| Ties | 124 | 183 |
| “Tie” ratio | 42.47 % | **62.67 %** |

Close games are now treated as _“can’t rule out chance at 95 %”_ rather than auto-wins.