### PR TITLE
Improve tie detection algorithm and statistics reporting

### DIFF
--- a/app/Console/Commands/RecomputeStats.php
+++ b/app/Console/Commands/RecomputeStats.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\RpsMatch;
+use Illuminate\Console\Command;
+
+class RecomputeStats extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:recompute-stats';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Recompute statistics for all matches';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->components->task(
+            'Recomputing Rock-Paper-Scissors Matches',
+            fn () => RpsMatch::with('player1', 'player2')->get()->each->recompute(),
+        );
+
+        $this->components->task(
+            'Recomputing Elo Ratings',
+            fn () => $this->callSilently('calculate:elo'),
+        );
+    }
+}

--- a/app/Http/Controllers/RpsMatchController.php
+++ b/app/Http/Controllers/RpsMatchController.php
@@ -38,13 +38,15 @@ class RpsMatchController extends Controller
                 'rpsMatchesAsPlayer1',
                 'rpsMatchesAsPlayer2',
                 'rpsMatchesWon',
+                'rpsMatchesAsPlayer1 as rps_matches_as_player1_tied_count' => fn (Builder $query) => $query->whereNull('winner_id'),
+                'rpsMatchesAsPlayer2 as rps_matches_as_player2_tied_count' => fn (Builder $query) => $query->whereNull('winner_id'),
             ])
             ->get()
             ->map(function ($model) {
                 $model->total_rps_matches = $model->rps_matches_as_player1_count + $model->rps_matches_as_player2_count;
-                $model->win_rate = $model->total_rps_matches > 0
-                    ? $model->rps_matches_won_count / $model->total_rps_matches
-                    : 0;
+                $model->rps_matches_tied_count = $model->rps_matches_as_player1_tied_count + $model->rps_matches_as_player2_tied_count;
+                $model->rps_matches_lost_count = $model->total_rps_matches - $model->rps_matches_won_count - $model->rps_matches_tied_count;
+                $model->win_rate = $model->rps_matches_won_count / max(1, $model->total_rps_matches);
 
                 return $model;
             })

--- a/resources/views/components/rps/game-rules.blade.php
+++ b/resources/views/components/rps/game-rules.blade.php
@@ -153,16 +153,12 @@
                 />
             </button>
 
-            <div
-                x-show="open"
-                x-collapse
-                class="mt-4 text-gray-700 leading-relaxed rounded p-4 bg-gray-50"
-            >
+            <div x-show="open" x-collapse class="mt-4 text-gray-700 leading-relaxed rounded p-4 bg-gray-50">
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <!-- 📝 Short story version -->
                     <div>
                         <p>
-                            We run a <strong>95 % two-sided binomial z-test.</strong>
+                            We run a <strong>90 % one-sided binomial z-test.</strong>
                             It answers one question: “Is the score gap big enough that luck
                             is an unlikely explanation?”
                         </p>
@@ -188,30 +184,21 @@
                     <div class="text-sm">
                         <p><strong>Hypotheses</strong></p>
                         <p>
-                            H₀: score₁ − score₂ = 0 (no skill)<br>
-                            H₁: score₁ − score₂ ≠ 0 (skill)
+                            H₀: winner win rate = 0.5 (no skill)<br>
+                            H₁: winner win rate > 0.5 (skill)
                         </p>
+
                         <p class="mt-3"><strong>Statistical Model</strong></p>
                         <p>
                             n = decisive rounds<br>
-                            X ~ Binomial(n, 0.5) &nbsp;(wins of Bot 1 under H₀)<br>
-                            D = score₁ − score₂ = 2X − n
+                            X ~ Binomial(n, 0.5) = winner's wins<br>
+                            z = (X / n − 0.5) / √(0.25 / n)
                         </p>
 
-                        <p class="mt-3"><strong>Under H₀</strong></p>
+                        <p class="mt-3"><strong>Decision rule (α = 0.05, one-sided)</strong></p>
                         <p>
-                            E[D] = 0  Var[D] = n → σ<sub>D</sub> = √n
-                        </p>
-
-                        <p class="mt-3"><strong>Test statistic</strong></p>
-                        <p>
-                            z = |D| / √n
-                        </p>
-
-                        <p class="mt-3"><strong>Decision rule (α = 0.05)</strong></p>
-                        <p>
-                            z &gt; 1.96 ⇔ |score₁ − score₂| &gt; 1.96 × √n
-                            → reject H₀ → call it “skill”
+                            z > 1.64 ⇒ we reject H₀ ⇒ declare skill<br>
+                            Otherwise ⇒ call it statistical tie
                         </p>
                     </div>
                 </div>

--- a/resources/views/components/rps/models-ranking-table.blade.php
+++ b/resources/views/components/rps/models-ranking-table.blade.php
@@ -20,10 +20,10 @@
                     <th scope="col" class="px-6 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wider">
                         RPS Matches
                     </th>
-                    <th scope="col" class="px-6 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                        RPS Wins
+                    <th scope="col" class="px-6 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                        Wins / Ties / Losses
                     </th>
-                    <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    <th scope="col" class="min-w-46 px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
                         Win Rate
                     </th>
                     <th scope="col" class="px-6 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wider">
@@ -64,17 +64,33 @@
                         <td class="px-6 py-3 text-right whitespace-nowrap">
                             <div class="text-sm text-gray-900">{{ $model->total_rps_matches }}</div>
                         </td>
-                        <td class="px-6 py-3 text-right whitespace-nowrap">
-                            <div class="text-sm text-gray-900">{{ $model->rps_matches_won_count }}</div>
+                        <td class="px-6 py-3">
+                            <div class="text-sm text-gray-900 flex flex-row gap-2 justify-center">
+                                <span class="w-6 text-center font-bold text-green-600">{{ $model->rps_matches_won_count }}</span>
+                                <span class="text-sm text-gray-400">/</span>
+                                <span class="w-6 text-center font-bold text-slate-600">{{ $model->rps_matches_tied_count }}</span>
+                                <span class="text-sm text-gray-400">/</span>
+                                <span class="w-6 text-center font-bold text-red-600">{{ $model->rps_matches_lost_count }}</span>
+                            </div>
                         </td>
-                        <td class="px-6 py-3 whitespace-nowrap">
+                        <td class="min-w-46 px-6 py-3 whitespace-nowrap">
                             @if($model->total_rps_matches > 0)
-                                <div class="flex items-center">
-                                    <span class="mr-2 text-sm font-medium {{ $model->win_rate > 0.5 ? 'text-green-600' : ($model->win_rate == 0.5 ? 'text-amber-600' : 'text-red-600') }}">
+                                <div class="flex items-center w-full">
+                                    <span class="w-12 text-right mr-2 text-sm font-medium shrink-0 text-slate-600">
                                         {{ Number::percentage($model->win_rate * 100, precision: 1) }}
                                     </span>
-                                    <div class="grow relative w-24 h-2 bg-gray-200 rounded-full overflow-hidden">
-                                        <div class="absolute top-0 left-0 h-2 rounded-full {{ $model->win_rate > 0.5 ? 'bg-green-500' : ($model->win_rate == 0.5 ? 'bg-amber-500' : 'bg-red-500') }}" style="width: {{ $model->win_rate * 100 }}%"></div>
+                                    {{-- Show Win/Ties/Looses progress --}}
+                                    <div class="flex h-2 w-full overflow-hidden rounded-full bg-gray-100">
+                                        @if($model->total_rps_matches > 0)
+                                            @php
+                                                $winPercent = $model->rps_matches_won_count / $model->total_rps_matches * 100;
+                                                $tiePercent = $model->rps_matches_tied_count / $model->total_rps_matches * 100;
+                                                $lossPercent = $model->rps_matches_lost_count / $model->total_rps_matches * 100;
+                                            @endphp
+                                            <div class="bg-green-500 h-full" style="width: {{ $winPercent }}%"></div>
+                                            <div class="bg-slate-300 h-full" style="width: {{ $tiePercent }}%"></div>
+                                            <div class="bg-red-500 h-full" style="width: {{ $lossPercent }}%"></div>
+                                        @endif
                                     </div>
                                 </div>
                             @else

--- a/resources/views/rps/matches/show.blade.php
+++ b/resources/views/rps/matches/show.blade.php
@@ -151,7 +151,7 @@
                             This match is considered a tie even though the scores differ by
                             <span class="font-semibold">{{ abs($rpsMatch->player1_score - $rpsMatch->player2_score) }} points</span>.
                             With {{ $rpsMatch->getDecisiveRounds() }} decisive rounds (Rounds not ending in a tie), that gap is not large enough to be statistically significant
-                            at 95 % confidence.
+                            at 90 % confidence.
                         </p>
                         <p class="mt-2 text-sm">
                             At this sample size, any difference below


### PR DESCRIPTION
The tie detection algorithm was inproved by changing it from a two-sided binomial z-test to a one-sided binomial z-test. This should better reflect the hypothesis we are trying to prove. 

**Extra changes**
- Updated the reporting of wins, ties, and losses in the user interface. 
- A new command for recomputing match statistics has been added to streamline data updates.