### PR TITLE
Add loser_id column to match models

### DIFF
--- a/app/Console/Commands/RecomputeStats.php
+++ b/app/Console/Commands/RecomputeStats.php
@@ -2,7 +2,9 @@
 
 namespace App\Console\Commands;
 
+use App\Models\ChessMatch;
 use App\Models\RpsMatch;
+use App\Models\SvgMatch;
 use Illuminate\Console\Command;
 
 class RecomputeStats extends Command
@@ -29,6 +31,16 @@ class RecomputeStats extends Command
         $this->components->task(
             'Recomputing Rock-Paper-Scissors Matches',
             fn () => RpsMatch::with('player1', 'player2')->get()->each->recompute(),
+        );
+
+        $this->components->task(
+            'Recomputing SVG Matches',
+            fn () => SvgMatch::with('player1', 'player2')->get()->each->recompute(),
+        );
+
+        $this->components->task(
+            'Recomputing Chess Matches',
+            fn () => ChessMatch::with('white', 'black')->get()->each->recompute(),
         );
 
         $this->components->task(

--- a/app/Http/Controllers/RpsMatchController.php
+++ b/app/Http/Controllers/RpsMatchController.php
@@ -38,6 +38,7 @@ class RpsMatchController extends Controller
                 'rpsMatchesAsPlayer1',
                 'rpsMatchesAsPlayer2',
                 'rpsMatchesWon',
+                'rpsMatchesLost',
                 'rpsMatchesAsPlayer1 as rps_matches_as_player1_tied_count' => fn (Builder $query) => $query->whereNull('winner_id'),
                 'rpsMatchesAsPlayer2 as rps_matches_as_player2_tied_count' => fn (Builder $query) => $query->whereNull('winner_id'),
             ])
@@ -45,7 +46,6 @@ class RpsMatchController extends Controller
             ->map(function ($model) {
                 $model->total_rps_matches = $model->rps_matches_as_player1_count + $model->rps_matches_as_player2_count;
                 $model->rps_matches_tied_count = $model->rps_matches_as_player1_tied_count + $model->rps_matches_as_player2_tied_count;
-                $model->rps_matches_lost_count = $model->total_rps_matches - $model->rps_matches_won_count - $model->rps_matches_tied_count;
                 $model->win_rate = $model->rps_matches_won_count / max(1, $model->total_rps_matches);
 
                 return $model;

--- a/app/Models/AiModel.php
+++ b/app/Models/AiModel.php
@@ -68,6 +68,14 @@ class AiModel extends Model
     }
 
     /**
+     * Get all RPS matches where this AI model lost
+     */
+    public function rpsMatchesLost(): HasMany
+    {
+        return $this->hasMany(RpsMatch::class, 'loser_id');
+    }
+
+    /**
      * Get all SVG matches where this AI model is player 1
      */
     public function svgMatchesAsPlayer1(): HasMany
@@ -92,6 +100,14 @@ class AiModel extends Model
     }
 
     /**
+     * Get all SVG matches where this AI model lost
+     */
+    public function svgMatchesLost(): HasMany
+    {
+        return $this->hasMany(SvgMatch::class, 'loser_id');
+    }
+
+    /**
      * Get all chess matches where this AI model plays as white
      */
     public function chessMatchesAsWhite(): HasMany
@@ -113,6 +129,14 @@ class AiModel extends Model
     public function chessMatchesWon(): HasMany
     {
         return $this->hasMany(ChessMatch::class, 'winner_id');
+    }
+
+    /**
+     * Get all chess matches where this AI model lost
+     */
+    public function chessMatchesLost(): HasMany
+    {
+        return $this->hasMany(ChessMatch::class, 'loser_id');
     }
 
     /**

--- a/app/Models/ChessMatch.php
+++ b/app/Models/ChessMatch.php
@@ -37,7 +37,27 @@ class ChessMatch extends Model implements RankedMatch
                     $model->white, $model->black, $model->result
                 )?->id;
             }
+
+            if (! isset($model->loser_id)) {
+                $model->loser_id = match ($model->winner_id) {
+                    $model->white_id => $model->black_id,
+                    $model->black_id => $model->white_id,
+                    default => null, // Draw
+                };
+            }
         });
+    }
+
+    /**
+     * Recompute the match statistics.
+     */
+    public function recompute(): void
+    {
+        // Just null the values so they can be recomputed again in the `saving` event
+        $this->update([
+            'winner_id' => null,
+            'loser_id' => null,
+        ]);
     }
 
     /**
@@ -79,6 +99,14 @@ class ChessMatch extends Model implements RankedMatch
     public function winner(): BelongsTo
     {
         return $this->belongsTo(AiModel::class, 'winner_id');
+    }
+
+    /**
+     * Get the AI model that lost the match
+     */
+    public function loser(): BelongsTo
+    {
+        return $this->belongsTo(AiModel::class, 'loser_id');
     }
 
     /**

--- a/app/Models/RpsMatch.php
+++ b/app/Models/RpsMatch.php
@@ -60,6 +60,14 @@ class RpsMatch extends Model implements RankedMatch
                 )?->id;
             }
 
+            if (! isset($model->loser_id)) {
+                $model->loser_id = match ($model->winner_id) {
+                    $model->player1_id => $model->player2_id,
+                    $model->player2_id => $model->player1_id,
+                    default => null,
+                };
+            }
+
             if (! isset($model->player1_win_streak)) {
                 $model->player1_win_streak = static::calculateWinStreak($model->move_history, player: 1);
             }
@@ -89,7 +97,10 @@ class RpsMatch extends Model implements RankedMatch
     {
         // Just null the values so they can be recomputed again in the `saving` event
         $this->update([
+            'player1_score' => null,
+            'player2_score' => null,
             'winner_id' => null,
+            'loser_id' => null,
             'player1_win_streak' => null,
             'player2_win_streak' => null,
             'rounds_played' => null,
@@ -164,6 +175,14 @@ class RpsMatch extends Model implements RankedMatch
     public function winner(): BelongsTo
     {
         return $this->belongsTo(AiModel::class, 'winner_id');
+    }
+
+    /**
+     * Get the AI model that lost the match
+     */
+    public function loser(): BelongsTo
+    {
+        return $this->belongsTo(AiModel::class, 'loser_id');
     }
 
     /**

--- a/database/migrations/2025_04_25_094746_add_loser_id_column.php
+++ b/database/migrations/2025_04_25_094746_add_loser_id_column.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('rps_matches', function (Blueprint $table) {
+            $table->foreignId('loser_id')->nullable()->constrained('ai_models'); // null = tie
+        });
+
+        Schema::table('svg_matches', function (Blueprint $table) {
+            $table->foreignId('loser_id')->nullable()->constrained('ai_models'); // null should not happen if everything works ok
+        });
+
+        Schema::table('chess_matches', function (Blueprint $table) {
+            $table->foreignId('loser_id')->nullable()->constrained('ai_models'); // null = draw
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('rps_matches', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('loser_id');
+        });
+
+        Schema::table('svg_matches', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('loser_id');
+        });
+
+        Schema::table('chess_matches', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('loser_id');
+        });
+    }
+};


### PR DESCRIPTION
Introduce a `loser_id` column to RPS, SVG, and Chess match models to track the losing player. Update relevant methods and statistics computations to accommodate this new field.