### PR TITLE
Update dependabot configuration for increased notifications

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,15 +9,20 @@
 
 version: 2
 updates:
-    - package-ecosystem: 'github-actions'
-      directory: '/'
-      schedule:
-          interval: 'weekly'
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
 
-    - package-ecosystem: 'npm'
-      directory: '/'
-      schedule:
-          interval: 'monthly'
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
 
-      #ignore:
-      # - dependency-name: "my-vendor/my-package"
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    #ignore:
+    # - dependency-name: "my-vendor/my-package"
+


### PR DESCRIPTION
Modify the dependabot configuration to include weekly updates for Composer dependencies, while retaining existing schedules for GitHub Actions and npm.