### PR TITLE
Add ai-model:delete command and improve ELO computation

### DIFF
--- a/app/Console/Commands/AiModels/DeleteModel.php
+++ b/app/Console/Commands/AiModels/DeleteModel.php
@@ -49,6 +49,7 @@ class DeleteModel extends Command
 
         if (! $model) {
             $this->error("Model with slug '{$modelSlug}' not found.");
+
             return Command::FAILURE;
         }
 

--- a/app/Console/Commands/AiModels/DeleteModel.php
+++ b/app/Console/Commands/AiModels/DeleteModel.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace App\Console\Commands\AiModels;
+
+use App\Models\AiModel;
+use App\Models\ChessMatch;
+use App\Models\RpsMatch;
+use App\Models\SvgMatch;
+use App\Services\EloRatingService;
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Support\Collection;
+
+use function Laravel\Prompts\select;
+
+class DeleteModel extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ai-models:delete
+        {--force : Force the operation to run when in production}
+        {model? : The slug of the model to delete}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete an AI model and all it\' matches from the database';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        if (! $this->confirmToProceed()) {
+            return Command::FAILURE;
+        }
+
+        $modelSlug = $this->argument('model') ?? $this->askModelSlug();
+
+        // Check if the model exists
+        $model = AiModel::where('slug', $modelSlug)->first();
+
+        if (! $model) {
+            $this->error("Model with slug '{$modelSlug}' not found.");
+            return Command::FAILURE;
+        }
+
+        // Delete the model and its matches
+        $count = [
+            'rps' => $this->deleteAndCount($this->getRpsMatches($model)),
+            'svg' => $this->deleteAndCount($this->getSvgMatches($model)),
+            'chess' => $this->deleteAndCount($this->getChessMatches($model)),
+        ];
+
+        $model->delete();
+
+        $this->table(
+            ['Match Type', 'Deleted Matches'],
+            [
+                ['RPS', $count['rps']],
+                ['SVG', $count['svg']],
+                ['Chess', $count['chess']],
+            ]
+        );
+
+        $this->info("Model '{$modelSlug}' and its matches have been deleted.");
+
+        $this->info('Updating Elo ratings...');
+
+        app(EloRatingService::class)->updateAll();
+
+        $this->info('Elo ratings updated.');
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Delete the given models and return the count of deleted matches.
+     */
+    protected function deleteAndCount(Collection $matches): int
+    {
+        $matches->each->delete();
+
+        return $matches->count();
+    }
+
+    /**
+     * Ask for the model slug if not provided.
+     */
+    protected function askModelSlug(): string
+    {
+        $models = AiModel::all();
+
+        return select(
+            label: 'Please select the model to delete',
+            options: $models->pluck('name', 'slug')->toArray(),
+            scroll: 30,
+        );
+    }
+
+    /**
+     * Get a collection of all RPS matches.
+     */
+    protected function getRpsMatches(AiModel $model): Collection
+    {
+        return RpsMatch::select('id')
+            ->where('player1_id', $model->id)
+            ->orWhere('player2_id', $model->id)
+            ->orWhere('winner_id', $model->id)
+            ->get();
+    }
+
+    /**
+     * Get a collection of all SVG matches.
+     */
+    protected function getSvgMatches(AiModel $model): Collection
+    {
+        return SvgMatch::select('id')
+            ->where('player1_id', $model->id)
+            ->orWhere('player2_id', $model->id)
+            ->orWhere('winner_id', $model->id)
+            ->get();
+    }
+
+    /**
+     * Get a collection of all Chess matches.
+     */
+    protected function getChessMatches(AiModel $model): Collection
+    {
+        return ChessMatch::select('id')
+            ->where('white_id', $model->id)
+            ->orWhere('black_id', $model->id)
+            ->orWhere('winner_id', $model->id)
+            ->get();
+    }
+}

--- a/app/Console/Commands/AiModels/SyncModels.php
+++ b/app/Console/Commands/AiModels/SyncModels.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace App\Console\Commands;
+namespace App\Console\Commands\AiModels;
 
 use App\Models\AiModel;
 use App\Services\AiClient\AiClientService;
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 
-class SyncAiModelsCommand extends Command
+class SyncModels extends Command
 {
     use ConfirmableTrait;
 
@@ -16,7 +16,7 @@ class SyncAiModelsCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'app:sync-ai-models
+    protected $signature = 'ai-models:sync
         {--force : Force the operation to run when in production}';
 
     /**

--- a/app/Console/Commands/Import/AbstractImport.php
+++ b/app/Console/Commands/Import/AbstractImport.php
@@ -72,6 +72,9 @@ abstract class AbstractImport extends Command
      */
     protected function aiModel(string $name): AiModel
     {
-        return AiModel::firstOrCreate(['slug' => Str::slug($name)]);
+        return AiModel::query()->firstOrCreate(
+            ['slug' => Str::slug($name)],
+            ['name' => $name],
+        );
     }
 }

--- a/app/Console/Commands/Import/ImportAll.php
+++ b/app/Console/Commands/Import/ImportAll.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands\Import;
 
+use App\Console\Commands\CalculateElo;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -43,20 +44,20 @@ class ImportAll extends Command
         }
 
         $this->components->task('Importing Chess Matches', function () {
-            return $this->callSilently('import:chess', ['--fresh' => $this->option('fresh')]) === 0;
+            return $this->call('import:chess', ['--fresh' => $this->option('fresh')]) === 0;
         });
 
         $this->components->task('Importing Rock-Paper-Scissors Matches', function () {
-            return $this->callSilently('import:rps', ['--fresh' => $this->option('fresh')]) === 0;
+            return $this->call('import:rps', ['--fresh' => $this->option('fresh')]) === 0;
         });
 
         $this->components->task('Importing SVG Matches', function () {
-            return $this->callSilently('import:svg', ['--fresh' => $this->option('fresh')]) === 0;
+            return $this->call('import:svg', ['--fresh' => $this->option('fresh')]) === 0;
         });
 
         if (! $this->option('skip-elo')) {
             $this->components->task('Calculating ELO Ratings', function () {
-                return $this->callSilently('calculate:elo') === 0;
+                return $this->call(CalculateElo::class) === 0;
             });
         }
 

--- a/app/Console/Concerns/RunsMatchups.php
+++ b/app/Console/Concerns/RunsMatchups.php
@@ -108,6 +108,7 @@ trait RunsMatchups
             }
 
             app(EloRatingService::class)->updateEloRatings($gameType);
+            app(EloRatingService::class)->updateOverallEloRatings();
 
             $this->reportResult($rankedMatch);
 

--- a/app/Services/EloRatingService.php
+++ b/app/Services/EloRatingService.php
@@ -24,6 +24,18 @@ class EloRatingService
     protected const DEFAULT_ELO = 1000;
 
     /**
+     * Update all ELO ratings for all matches.
+     */
+    public function updateAll(): void
+    {
+        $this->updateRpsEloRatings();
+        $this->updateSvgEloRatings();
+        $this->updateChessEloRatings();
+
+        $this->updateOverallEloRatings();
+    }
+
+    /**
      * Update ELO ratings for all RPS matches.
      */
     public function updateRpsEloRatings(): void


### PR DESCRIPTION
Introduce a command to delete an AI model along with its associated matches, ensuring proper confirmation and feedback. Enhance ELO rating updates to reflect changes across all match types after deletions. Adjust existing commands for consistency in naming and functionality.