### PR TITLE
Add retry mechanism for invalid SVG submissions

### DIFF
--- a/app/Console/Commands/Benchmark/BenchmarkSvgCommand.php
+++ b/app/Console/Commands/Benchmark/BenchmarkSvgCommand.php
@@ -55,6 +55,7 @@ class BenchmarkSvgCommand extends Command
                 game: $game,
                 onPromptGenerated: fn ($game) => $this->reportPromptGenerated($game),
                 onSvgSubmitted: fn ($game, $player) => $this->reportSvgSubmission($game, $player),
+                onInvalidSvg: fn ($game, $player, $e) => $this->reportInvalidSvg($game, $player, $e),
             );
 
             return $this->createMatch($game);
@@ -115,6 +116,17 @@ class BenchmarkSvgCommand extends Command
         $count = strlen($game->getPlayerSvg($player) ?? '');
 
         $this->line("$emoji SVG submitted by {$game->getPlayer($player)->name} ($count characters)");
+    }
+
+    /**
+     * Report when an invalid SVG is submitted.
+     */
+    protected function reportInvalidSvg(SvgGame $game, SvgPlayer $player, Exception $e): void
+    {
+        $emoji = $player === SvgPlayer::Player1 ? '🔴' : '🔵';
+        $this->newLine();
+        $this->error("$emoji Invalid SVG submitted by {$game->getPlayer($player)->name}");
+        $this->error('⚠️ '.$e->getMessage());
     }
 
     /**

--- a/app/Services/Svg/SvgBenchmarkService.php
+++ b/app/Services/Svg/SvgBenchmarkService.php
@@ -106,11 +106,13 @@ class SvgBenchmarkService
             callback: function (int $attempts) use ($game, $player) {
                 $svg1 = $this->getPlayerSvg($game, $player, $attempts);
                 $game->setSvg($player, $svg1);
+
                 return $this->svgService->svgToPng($svg1, width: 300, height: 300);
             },
             when: function ($e) use ($game, $player, $onInvalidSvg) {
                 if ($e instanceof SvgImageException) {
                     $onInvalidSvg($game, $player, $e);
+
                     return true; // Retry on invalid SVG
                 }
 
@@ -157,7 +159,7 @@ class SvgBenchmarkService
             '',
             'Push the boundaries of SVG capabilities while maintaining technical excellence.',
             '',
-            'Return ONLY valid SVG code in your response.'
+            'Return ONLY valid SVG code in your response.',
         ]);
 
         if ($failedAttempts > 1) {

--- a/app/Services/Svg/SvgImageException.php
+++ b/app/Services/Svg/SvgImageException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Services\Svg;
+
+use Exception;
+
+class SvgImageException extends Exception
+{
+    //
+}

--- a/app/Services/Svg/SvgImageService.php
+++ b/app/Services/Svg/SvgImageService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Svg;
 
+use Illuminate\Process\Exceptions\ProcessFailedException;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
@@ -68,6 +69,8 @@ class SvgImageService
 
     /**
      * Convert SVG to PNG binary data.
+     *
+     * @throws SvgImageException
      */
     protected function convertSvgToPng(string $svgString, int $width, int $height): string
     {
@@ -90,6 +93,12 @@ class SvgImageService
             ])->throw();
 
             return file_get_contents($outputFile);
+        } catch (ProcessFailedException $e) {
+            throw new SvgImageException(
+                message: 'SVG to PNG conversion failed: '.$e->result->errorOutput(),
+                code: $e->getCode(),
+                previous: $e
+            );
         } finally {
             if (file_exists($inputFile)) {
                 unlink($inputFile);


### PR DESCRIPTION
Implement a retry mechanism for generating SVGs when invalid submissions occur, along with error reporting for invalid SVGs. Introduce a custom exception for SVG-related errors.