### PR TITLE
Fix comparison symbols in SVG Stats and Insights

### DIFF
--- a/resources/views/svg/matches/show.blade.php
+++ b/resources/views/svg/matches/show.blade.php
@@ -348,13 +348,13 @@
                                             <!-- Comparison indicator -->
                                             <div class="w-12 flex items-center justify-center">
                                                 @if(isset($feature['delta']) && is_numeric($feature['delta']))
-                                                    @if($feature['delta'] < 0)
+                                                    @if($feature['delta'] > 0)
                                                         <span class="size-6 rounded-full bg-red-100 flex items-center justify-center" title="Player 1 has higher value">
-                                                            <x-phosphor-less-than-bold class="size-4 text-red-700" />
+                                                            <x-phosphor-greater-than-bold class="size-4 text-red-700" />
                                                         </span>
-                                                    @elseif($feature['delta'] > 0)
+                                                    @elseif($feature['delta'] < 0)
                                                         <span class="size-6 rounded-full bg-blue-100 flex items-center justify-center" title="Player 2 has higher value">
-                                                            <x-phosphor-greater-than-bold class="size-4 text-blue-700" />
+                                                            <x-phosphor-less-than-bold class="size-4 text-blue-700" />
                                                         </span>
                                                     @else
                                                         <span class="size-6 rounded-full bg-slate-200 flex items-center justify-center" title="Equal values">


### PR DESCRIPTION
Correct the comparison symbols for delta values in the SVG Stats and Insights to accurately reflect the relationship between player values.