### PR TITLE
Fix incorrect SVG label

### DIFF
--- a/resources/views/components/svg/models-ranking-table.blade.php
+++ b/resources/views/components/svg/models-ranking-table.blade.php
@@ -12,7 +12,7 @@
                         Model
                     </th>
                     <th scope="col" class="px-6 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                        RPS Matches
+                        SVG Matches
                     </th>
                     <th scope="col" class="px-6 py-3 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider">
                         Wins / Losses


### PR DESCRIPTION
Update the table header label from "RPS Matches" to "SVG Matches" for clarity.

![image](https://github.com/user-attachments/assets/3b869d8b-eed9-4ed5-a490-0d0ffa998743)
