### PR TITLE
Add matchup algorithm configuration

### DIFF
--- a/app/Console/Concerns/RunsMatchups.php
+++ b/app/Console/Concerns/RunsMatchups.php
@@ -35,7 +35,7 @@ trait RunsMatchups
         }
 
         if ($this->option('no-interaction')) {
-            return app(PlayerSelectionService::class)->random($game, $aiModels);
+            return app(PlayerSelectionService::class)->first($game, $aiModels);
         }
 
         $aiModels = collect($aiModels);

--- a/config/playbench.php
+++ b/config/playbench.php
@@ -30,6 +30,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Matchup configuration
+    |--------------------------------------------------------------------------
+    |
+    | The algorithm used to determine the participants in a matchup.
+    | Values can be: `random`, `less_matches`
+    |
+    */
+
+    'matchup_algorithm' => env('PLAYBENCH_MATCHUP_ALGORITHM', 'random'),
+
+    /*
+    |--------------------------------------------------------------------------
     | AI Models
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Introduce a configuration option for selecting the algorithm used to determine participants in a matchup, allowing for either a random selection or a selection based on the least number of matches played. This enhances flexibility in player selection strategies.