### PR TITLE
Add "auto run" mode for benchmarks

### DIFF
--- a/app/Services/PlayerSelectionService.php
+++ b/app/Services/PlayerSelectionService.php
@@ -62,6 +62,7 @@ class PlayerSelectionService
                 matchesPlayed: $countByPairs->get($this->getKey($p1->id, $p2->id), 0),
                 random: true,
             ))
+            ->shuffle()
             ->sortBy('matchesPlayed')
             ->values(); // Re-index the collection
     }

--- a/config/playbench.php
+++ b/config/playbench.php
@@ -40,6 +40,15 @@ return [
 
     'matchup_algorithm' => env('PLAYBENCH_MATCHUP_ALGORITHM', 'random'),
 
+    'auto_run' => [
+        'matches' => env('AUTO_RUN_MATCHES', 10),
+        'notify_to' => explode(',', env('AUTO_RUN_NOTIFY_TO', '')),
+
+        'svg' => env('AUTO_RUN_SVG', false),
+        'rps' => env('AUTO_RUN_RPS', false),
+        'chess' => env('AUTO_RUN_CHESS', false),
+    ],
+
     /*
     |--------------------------------------------------------------------------
     | AI Models

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,8 +1,35 @@
 <?php
 
+use App\Console\Commands\Benchmark\BenchmarkChessCommand;
+use App\Console\Commands\Benchmark\BenchmarkRpsCommand;
+use App\Console\Commands\Benchmark\BenchmarkSvgCommand;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+$notifyTo = config('playbench.auto_run.notify_to');
+$matches = config('playbench.auto_run.matches', 10);
+
+$args = ['--no-interaction', '--matches' => $matches];
+
+if (config('playbench.auto_run.svg')) {
+    Schedule::command(BenchmarkSvgCommand::class, $args)
+        ->daily()
+        ->emailOutputTo($notifyTo);
+}
+
+if (config('playbench.auto_run.rps')) {
+    Schedule::command(BenchmarkRpsCommand::class, $args)
+        ->daily()
+        ->emailOutputTo($notifyTo);
+}
+
+if (config('playbench.auto_run.chess')) {
+    Schedule::command(BenchmarkChessCommand::class, $args)
+        ->daily()
+        ->emailOutputTo($notifyTo);
+}


### PR DESCRIPTION
Introduce an "auto run" mode that schedules daily benchmark commands for SVG, RPS, and chess based on configuration settings. This mode allows for automated execution and notification of benchmark results.