### PR TITLE
Add frontend-tests CI job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,3 +74,23 @@ jobs:
 
     - name: Check code style
       run: ./vendor/bin/pint --test
+
+  frontend-tests:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '22.x'
+        cache: 'npm'
+
+    - name: Install Dependencies
+      run: npm ci
+
+    - name: Build assets
+      run: npm run build


### PR DESCRIPTION
Adds a `frontend-tests` job (Node + `npm ci` + `npm run build`) to the Tests workflow so frontend build breakage gets caught in CI instead of at deploy/runtime. Mirrors the setup we have in nexus.

Context: cookie-clicker-web shipped a broken production release two weeks ago because a vite peer-dep bump made `npm ci` fail on Forge, the deploy script didn't halt, and CI never built the frontend so nothing caught it. This closes that gap for every production web repo.